### PR TITLE
Nested charts with `d3-graph` component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-1.13
 
 before_install:
   - npm config set spin false

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ It can be used inline.
 It can be nested to allow multiple graph pipes to be rendered into the root component.
 
 ```hbs
-{{#d3-graph as |selection|}}
-  {{d3-graph selection (pipe ...)}}
-  {{d3-graph selection (pipe ...)}}
+{{#d3-graph as |d3|}}
+  {{d3.graph (pipe ...)}}
+  {{d3.graph (pipe ...)}}
 {{/d3-graph}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@
 
 # ember-d3-helpers
 
-This library provides a suite of Ember helpers around the d3v4 API. Support for more features is ongoing.
+This library provides a collection of helpers for building D3 graphs via Ember.js templates. 
+Component and helpers provided in this library are intended to be primitives that one could use to build a D3 graphs.
+
+Support for more features is ongoing.
 
 ## Configuration
 
@@ -14,7 +17,8 @@ Currently, there are no configuration options for this addon in `config/environm
 
 ## Live Examples
 
-You can view a demo of a few ways to use these helpers [here](http://locusenergy.github.io/ember-d3-helpers)
+You can view a demo of a few ways to use these helpers [here](http://locusenergy.github.io/ember-d3-helpers). 
+Checkout [`ember-sparkles`](https://github.com/LocusEnergy/ember-sparkles) to see example implementations using these primitives.
 
 ## Available Helpers
 * [`d3-graph`](#d3-graph)

--- a/README.md
+++ b/README.md
@@ -64,18 +64,14 @@ It can be used inline.
 )}}
 ```
 
-Or as a block component.
+It can be nested to allow multiple graph pipes to be rendered into the root component.
 
 ```hbs
-{{#d3-graph (pipe
-  (d3-select-all "rect")
-  (d3-attr "name" "fred")
-)}}
-  <rect></rect>
+{{#d3-graph as |selection|}}
+  {{d3-graph selection (pipe ...)}}
+  {{d3-graph selection (pipe ...)}}
 {{/d3-graph}}
 ```
-
-The template in the block becomes the initial DOM for this graph. 
 
 ### Selection Helpers
 

--- a/addon/components/d3-graph.js
+++ b/addon/components/d3-graph.js
@@ -3,32 +3,12 @@ import { select } from 'd3-selection';
 import layout from '../templates/components/d3-graph';
 
 const {
-  isNone,
-  typeOf,
-  defineProperty,
-  computed: { oneWay }
+  isNone
 } = Ember;
 
 export default Ember.Component.extend({
   layout,
   tagName: 'g',
-
-  init() {
-    this._super(...arguments);
-    let { _selection, _graph } = this.getProperties(['_selection', '_graph']);
-
-    let isNested = _selection && _graph;
-    if (isNested) {
-      defineProperty(this, 'selection', oneWay('_selection'));
-      defineProperty(this, 'graph', oneWay('_graph'));
-      return;
-    }
-
-    if (isNone(_graph) && typeOf(_selection) === 'function') {
-      defineProperty(this, 'graph', oneWay('_selection'));
-      return;
-    }
-  },
 
   didInsertElement() {
     this._super(...arguments);
@@ -44,5 +24,5 @@ export default Ember.Component.extend({
     this.set('selection', select(el));
   }
 }).reopenClass({
-  positionalParams: ['_selection', '_graph']
+  positionalParams: ['graph']
 });

--- a/addon/components/d3-graph.js
+++ b/addon/components/d3-graph.js
@@ -2,12 +2,42 @@ import Ember from 'ember';
 import { select } from 'd3-selection';
 import layout from '../templates/components/d3-graph';
 
+const {
+  isNone,
+  typeOf,
+  defineProperty,
+  computed: { oneWay }
+} = Ember;
+
 export default Ember.Component.extend({
   layout,
   tagName: 'g',
+
+  init() {
+    this._super(...arguments);
+    let { _selection, _graph } = this.getProperties(['_selection', '_graph']);
+
+    let isNested = _selection && _graph;
+    if (isNested) {
+      defineProperty(this, 'selection', oneWay('_selection'));
+      defineProperty(this, 'graph', oneWay('_graph'));
+      this.set('tagName', '');
+      return;
+    }
+
+    if (isNone(_graph) && typeOf(_selection) === 'function') {
+      defineProperty(this, 'graph', oneWay('_selection'));
+      return;
+    }
+  },
+
   didInsertElement() {
     this._super(...arguments);
-    Ember.run.scheduleOnce('afterRender', this, 'renderChart');
+
+    let selection = this.get('selection');
+    if (isNone(selection)) {
+      Ember.run.scheduleOnce('afterRender', this, 'renderChart');
+    }
   },
 
   renderChart() {
@@ -15,5 +45,5 @@ export default Ember.Component.extend({
     this.set('selection', select(el));
   }
 }).reopenClass({
-  positionalParams: ['graph']
+  positionalParams: ['_selection', '_graph']
 });

--- a/addon/components/d3-graph.js
+++ b/addon/components/d3-graph.js
@@ -21,7 +21,6 @@ export default Ember.Component.extend({
     if (isNested) {
       defineProperty(this, 'selection', oneWay('_selection'));
       defineProperty(this, 'graph', oneWay('_graph'));
-      this.set('tagName', '');
       return;
     }
 

--- a/addon/templates/components/d3-graph.hbs
+++ b/addon/templates/components/d3-graph.hbs
@@ -1,8 +1,17 @@
 {{#if selection}}
-  {{#if graph}}
-    {{shhh (compute graph selection)}}
+  {{#if hasBlock}}
+    {{#if graph}}
+      {{yield (hash
+        graph=(component 'd3-graph' selection=(compute (pipe graph (r/param)) selection) tagName='')
+      )}}
+    {{else}}
+      {{yield (hash
+        graph=(component 'd3-graph' selection=selection tagName='')
+      )}}
+    {{/if}}
+  {{else}}
+    {{#if graph}}
+      {{shhh (compute graph selection)}}
+    {{/if}}
   {{/if}}
-  {{yield (hash
-    graph=(component 'd3-graph' selection=selection tagName='')
-  )}}
 {{/if}}

--- a/addon/templates/components/d3-graph.hbs
+++ b/addon/templates/components/d3-graph.hbs
@@ -1,5 +1,5 @@
-{{yield selection}}
 {{#if selection}}
+  {{yield selection}}
   {{#if graph}}
     {{shhh (compute graph selection)}}
   {{/if}}

--- a/addon/templates/components/d3-graph.hbs
+++ b/addon/templates/components/d3-graph.hbs
@@ -1,8 +1,8 @@
 {{#if selection}}
-  {{yield (hash
-    graph=(component 'd3-graph' selection=selection tagName='')
-  )}}
   {{#if graph}}
     {{shhh (compute graph selection)}}
   {{/if}}
+  {{yield (hash
+    graph=(component 'd3-graph' selection=selection tagName='')
+  )}}
 {{/if}}

--- a/addon/templates/components/d3-graph.hbs
+++ b/addon/templates/components/d3-graph.hbs
@@ -1,5 +1,7 @@
 {{#if selection}}
-  {{yield selection}}
+  {{yield (hash
+    graph=(component 'd3-graph' selection=selection tagName='')
+  )}}
   {{#if graph}}
     {{shhh (compute graph selection)}}
   {{/if}}

--- a/addon/templates/components/d3-graph.hbs
+++ b/addon/templates/components/d3-graph.hbs
@@ -1,17 +1,11 @@
-{{#if selection}}
-  {{#if hasBlock}}
-    {{#if graph}}
-      {{yield (hash
-        graph=(component 'd3-graph' selection=(compute (pipe graph (r/param)) selection) tagName='')
-      )}}
-    {{else}}
-      {{yield (hash
-        graph=(component 'd3-graph' selection=selection tagName='')
-      )}}
-    {{/if}}
-  {{else}}
-    {{#if graph}}
-      {{shhh (compute graph selection)}}
-    {{/if}}
-  {{/if}}
+{{#if (and selection hasBlock graph)}}
+  {{yield (hash
+    graph=(component 'd3-graph' selection=(compute (pipe graph (r/param)) selection) tagName='')
+  )}}
+{{else if (and selection hasBlock (not graph))}}
+  {{yield (hash
+    graph=(component 'd3-graph' selection=selection tagName='')
+  )}}
+{{else if (and selection graph)}}
+  {{shhh (compute graph selection)}}  
 {{/if}}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-d3-shape": "0.9.4-4.1.1.0",
     "ember-composable-helpers": "0.27.0",
-    "ember-reactive-helpers": "0.3.5"
+    "ember-reactive-helpers": "0.3.5",
+    "ember-truth-helpers": "1.2.0"    
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/integration/components/d3-graph-test.js
+++ b/tests/integration/components/d3-graph-test.js
@@ -1,24 +1,19 @@
-// import { moduleForComponent, test } from 'ember-qunit';
-// import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
 
-// moduleForComponent('d3-graph', 'Integration | Component | d3 graph', {
-//   integration: true
-// });
+moduleForComponent('d3-graph', 'Integration | Component | d3 graph', {
+  integration: true
+});
 
-// test('it renders', function(assert) {
-//   // Set any properties with this.set('myProperty', 'value');
-//   // Handle any actions with this.on('myAction', function(val) { ... });
+test('it allows to render multiple nested graphs', function(assert) {
+  this.render(hbs`
+    {{#d3-graph as |selection|}}
+      {{d3-graph selection (pipe (d3-append "rect") (d3-attr "name" "foo"))}}
+      {{d3-graph selection (pipe (d3-append "rect") (d3-attr "name" "bar"))}}      
+    {{/d3-graph}}
+  `);
 
-//   this.render(hbs`{{d3-graph}}`);
-
-//   assert.equal(this.$().text().trim(), '');
-
-//   // Template block usage:
-//   this.render(hbs`
-//     {{#d3-graph}}
-//       template block text
-//     {{/d3-graph}}
-//   `);
-
-//   assert.equal(this.$().text().trim(), 'template block text');
-// });
+  assert.ok(this.$('g').length, 1, "only one g is rendered");
+  assert.ok(this.$('rect[name=foo]').length, 1, "rect name foo is rendered");
+  assert.ok(this.$('rect[name=bar]').length, 1, "rect name bar is rendered");  
+});

--- a/tests/integration/components/d3-graph-test.js
+++ b/tests/integration/components/d3-graph-test.js
@@ -17,3 +17,22 @@ test('it allows to render multiple nested graphs', function(assert) {
   assert.ok(this.$('rect[name=foo]').length, 1, "rect name foo is rendered");
   assert.ok(this.$('rect[name=bar]').length, 1, "rect name bar is rendered");  
 });
+
+test('passing graph pipe yields piped selection', function(assert){
+
+  this.render(hbs`
+    {{#d3-graph (pipe 
+      (d3-append "rect")
+      (d3-attr "class" "piped")
+    ) as |d3|}}
+      {{d3.graph (pipe
+        (d3-append "rect")
+        (d3-attr "class" "deeply-nested")
+      )}}
+    {{/d3-graph}}
+  `);
+
+  assert.ok(this.$('rect.piped').length, "rect with class piped is rendered");
+  assert.ok(this.$('rect.piped > rect.deeply-nested').length, "rect.deeply-nested in piped");
+
+});

--- a/tests/integration/components/d3-graph-test.js
+++ b/tests/integration/components/d3-graph-test.js
@@ -7,9 +7,9 @@ moduleForComponent('d3-graph', 'Integration | Component | d3 graph', {
 
 test('it allows to render multiple nested graphs', function(assert) {
   this.render(hbs`
-    {{#d3-graph as |selection|}}
-      {{d3-graph selection (pipe (d3-append "rect") (d3-attr "name" "foo"))}}
-      {{d3-graph selection (pipe (d3-append "rect") (d3-attr "name" "bar"))}}      
+    {{#d3-graph as |d3|}}
+      {{d3.graph (pipe (d3-append "rect") (d3-attr "name" "foo"))}}
+      {{d3.graph (pipe (d3-append "rect") (d3-attr "name" "bar"))}}      
     {{/d3-graph}}
   `);
 

--- a/tests/integration/helpers/d3-attr-test.js
+++ b/tests/integration/helpers/d3-attr-test.js
@@ -13,8 +13,6 @@ test('applies attribute to selection', function(assert) {
     )}}
   `);
 
-  this.set('ready', true);
-
   assert.equal(this.$('g').attr('name'), 'applied');
 });
 
@@ -28,8 +26,6 @@ test('updates element when bound property changes', function(assert){
       (d3-attr "name" name)
     )}}
   `);
-
-  this.set('ready', true);
 
   assert.equal(this.$('g').attr('name'), 'initial value');
 

--- a/tests/integration/helpers/d3-call-test.js
+++ b/tests/integration/helpers/d3-call-test.js
@@ -7,9 +7,19 @@ moduleForComponent('d3-call', 'Integration | Helper | d3-call', {
 
 test('executes callback without changing piped value', function(assert) {
 
+  this.set('data', ['car', 'car', 'boat', 'boat']);
+
   this.render(hbs`
-    {{#d3-graph (pipe 
-      (d3-call (pipe 
+    {{d3-graph (pipe
+      (d3-call (pipe
+        (d3-select-all "i")
+        (d3-data data)
+        (d3-join enter=(pipe 
+          (d3-append "i")
+          (d3-attr "class" (r/param))
+        ))
+      ))
+      (d3-call (pipe
         (d3-select-all ".car")
         (d3-attr "color" "red")
       ))
@@ -20,11 +30,6 @@ test('executes callback without changing piped value', function(assert) {
       (d3-append 'i')
       (d3-attr "class" "truck")
     )}}
-      <i class="car"></i>
-      <i class="car"></i>
-      <i class="boat"></i>
-      <i class="boat"></i>
-    {{/d3-graph}}
   `);
 
   assert.equal(this.$('.car[color=red]').length, 2, "color red was applied to cars");

--- a/tests/integration/helpers/d3-select-all-test.js
+++ b/tests/integration/helpers/d3-select-all-test.js
@@ -6,16 +6,23 @@ moduleForComponent('d3-select-all', 'Integration | Helper | d3-select-all', {
 });
 
 test('selects multiple elements', function(assert) {
+
+  this.set('data', ['a', 'a b', 'b c']);
+
   // Template block usage:
   this.render(hbs`
-    {{#d3-graph (pipe
-        (d3-select-all "i.a")
-        (d3-text "matched")
-      )}}
-      <i class="a"></i>
-      <i class="a b"></i>
-      <i class="b c"></i>
-    {{/d3-graph}}
+    {{d3-graph (pipe
+      (d3-call (pipe
+        (d3-select-all "i")
+        (d3-data data)
+        (d3-join enter=(pipe
+          (d3-append "i")
+          (d3-attr "class" (r/param))
+        ))
+      ))      
+      (d3-select-all "i.a")
+      (d3-text "matched")
+    )}}      
   `);
 
   assert.ok(this.$('i.a:contains(matched)').length);
@@ -25,20 +32,24 @@ test('selects multiple elements', function(assert) {
 
 test('selection changes when selector is changed', function(assert){
 
+  this.set('data', ['a', 'a', 'b', 'b']);
+
   this.set('selector', '.a');
 
   // Template block usage:
   this.render(hbs`
-    {{#d3-graph (pipe
-      (d3-select ".selection-container")
+    {{d3-graph (pipe
+      (d3-call (pipe
+        (d3-select-all "i")
+        (d3-data data)
+        (d3-join enter=(pipe
+          (d3-append "i")
+          (d3-attr "class" (r/param))
+        ))
+      ))
       (d3-select selector)
       (d3-text "matched")
     )}}
-      <i class="a"></i>
-      <i class="a"></i>
-      <i class="b"></i>
-      <i class="b"></i>
-    {{/d3-graph}}
   `);
 
   assert.ok(this.$('.a:contains(matched)').length);

--- a/tests/integration/helpers/d3-select-all-test.js
+++ b/tests/integration/helpers/d3-select-all-test.js
@@ -38,18 +38,19 @@ test('selection changes when selector is changed', function(assert){
 
   // Template block usage:
   this.render(hbs`
-    {{d3-graph (pipe
-      (d3-call (pipe
+    {{#d3-graph (pipe
         (d3-select-all "i")
         (d3-data data)
         (d3-join enter=(pipe
           (d3-append "i")
           (d3-attr "class" (r/param))
         ))
-      ))
-      (d3-select selector)
-      (d3-text "matched")
-    )}}
+      ) as |d3|}}
+      {{d3.graph (pipe
+        (d3-select selector)
+        (d3-text "matched")
+      )}}
+    {{/d3-graph}}
   `);
 
   assert.ok(this.$('.a:contains(matched)').length);

--- a/tests/integration/helpers/d3-select-test.js
+++ b/tests/integration/helpers/d3-select-test.js
@@ -8,14 +8,14 @@ moduleForComponent('d3-select', 'Integration | Helper | d3-select', {
 test('it renders', function(assert) {
 
   this.render(hbs`
-  {{d3-graph (pipe 
-    (d3-call (pipe
-      (d3-append "a")
-      (d3-attr "id" "my-link")
-    ))
-    (d3-select "#my-link")
-    (d3-attr "name" "fred")
-  )}}
+    {{d3-graph (pipe 
+      (d3-call (pipe
+        (d3-append "a")
+        (d3-attr "id" "my-link")
+      ))
+      (d3-select "#my-link")
+      (d3-attr "name" "fred")
+    )}}
   `);
 
   assert.equal(this.$('#my-link').attr('name'), 'fred');

--- a/tests/integration/helpers/d3-select-test.js
+++ b/tests/integration/helpers/d3-select-test.js
@@ -8,15 +8,15 @@ moduleForComponent('d3-select', 'Integration | Helper | d3-select', {
 test('it renders', function(assert) {
 
   this.render(hbs`
-  {{#d3-graph (pipe 
+  {{d3-graph (pipe 
+    (d3-call (pipe
+      (d3-append "a")
+      (d3-attr "id" "my-link")
+    ))
     (d3-select "#my-link")
     (d3-attr "name" "fred")
   )}}
-    <a id="my-link"></a>  
-  {{/d3-graph}}
   `);
-
-  this.set('ready', true);
 
   assert.equal(this.$('#my-link').attr('name'), 'fred');
 });


### PR DESCRIPTION
PR for #19 

`d3-graph` can now be nested. The child components are rendered as contextual components with `tagName=''`

```hbs
{{#d3-graph as |d3|}}
  {{d3.graph (pipe ...)}}
  {{d3.graph (pipe ...)}}
{{/d3-graph}}
```

Making these contextual components has the unfortunate side effect of requiring Ember 2.3+. What are your thoughts on this?

/cc @ivanvanderbyl @zigahertz 