### PR TITLE
Fixed possible mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Selects all elements that match the specified selector string.
 ```hbs
 {{d3-graph (pipe
   (d3-select-all "rect")
-  (d3-join data)
+  (d3-data data)
   (d3-style "color" "red")
 )}}
 ```


### PR DESCRIPTION
This addon is amazing!

I'm new to D3 and I found all existing Ember D3 wrappers to be frustrating due to their imperative nature.

But the declarativeness of `ember-d3-helpers` is genius! :+1: 

 I've been trying to grasp the readme and found a possible inconsistency. Feel free to discard the PR if I'm wrong. But if you do, please update the readme to explain the inconsistency.