### PR TITLE
Switch to ember-d3 now that ember-cli-d3-shape is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi
   - npm config set spin false
   - npm install -g bower
   - bower --version

--- a/addon/helpers/d3-array.js
+++ b/addon/helpers/d3-array.js
@@ -4,7 +4,7 @@ import array from 'd3-array';
 let allowedMethods = Ember.A(['min', 'max', 'extent', 'sum', 'mean', 'median', 'variance', 'deviation', 'scan', 'merge', 'pairs', 'permute']);
 
 export function d3Array([ method, ...args ]) {
-  Ember.assert('this method is not yet supported', allowedMethods.contains(method));
+  Ember.assert('this method is not yet supported', allowedMethods.includes(method));
 
   let arrayMethod = array[method];
   return arrayMethod.apply(null, args);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-d3-shape": "0.9.4-4.1.1.0",
+    "d3": "^4.2.0",
+    "ember-d3": "ivanvanderbyl/ember-d3",
     "ember-composable-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.5",
     "ember-truth-helpers": "1.2.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.0.3",
     "d3": "^4.2.0",
-    "ember-d3": "ivanvanderbyl/ember-d3",
+    "ember-d3": "^0.3.0",
     "ember-composable-helpers": "1.0.0",
     "ember-reactive-helpers": "0.3.5",
     "ember-truth-helpers": "1.2.0"


### PR DESCRIPTION
It's coming time to retire `ember-cli-d3-shape` and use `ember-d3` once we cut a new release. I've opened this PR to test compatibility with the new module resolving behaviour before calling it Production Ready™.

**Update 10/17/16**

Tests run, everything seems to be good to go. Can someone confirm this in another app?

- [ ] Confirmed in a parent app